### PR TITLE
Support polymorphic types in schema generator

### DIFF
--- a/src/Data/OpenApi/Schema.hs
+++ b/src/Data/OpenApi/Schema.hs
@@ -13,6 +13,8 @@ module Data.OpenApi.Schema (
   toSchemaRef,
   schemaName,
   toInlinedSchema,
+  ToSchema1(..),
+  BySchema1(..),
 
   -- * Generic schema encoding
   genericDeclareNamedSchema,


### PR DESCRIPTION
This commit adds a way to generate schemas for types of kind `Type ->
Type`, correctly setting the name for each concrete schema. Previously
an attempt to use polymorphic types with `ToSchema` instance led to the
same schema being duplicated for all concrete types.

Fixes https://github.com/biocad/servant-openapi3/issues/4