### PR TITLE
Include the scheme when using http security

### DIFF
--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -91,6 +91,7 @@ module Data.OpenApi (
   -- ** Security
   SecurityScheme(..),
   SecuritySchemeType(..),
+  HttpSchemeType(..),
   SecurityDefinitions(..),
   SecurityRequirement(..),
 


### PR DESCRIPTION
Using https://editor.swagger.io/ to view the API it was complaining about the `scheme` property not being included when using http auth. 

I used this with `servant-auth` and an orphan instance of `HasOpenApi`:

``` haskell
instance HasOpenApi sub => HasOpenApi (Auth '[JWT] AuthToken :> sub) where
    toOpenApi _ = authStuff <> toOpenApi (Proxy @sub)
      where
        authStuff :: OpenApi
        authStuff =
            mempty
                &   components
                .   securitySchemes
                <>~ [ ( "BearerAuth"
                      , SecurityScheme (SecuritySchemeHttp HttpSchemeBearer)
                                       (Just "Bearer authentication")
                      )
                    ]
                &   security
                <>~ [SecurityRequirement [("BearerAuth", [])]]
```