### PR TITLE
Use date-time format for ZonedTime

### DIFF
--- a/src/Data/OpenApi/Internal/ParamSchema.hs
+++ b/src/Data/OpenApi/Internal/ParamSchema.hs
@@ -216,9 +216,9 @@ instance ToParamSchema LocalTime where
 
 -- |
 -- >>> toParamSchema (Proxy :: Proxy ZonedTime) ^. format
--- Just "yyyy-mm-ddThh:MM:ss+hhMM"
+-- Just "date-time"
 instance ToParamSchema ZonedTime where
-  toParamSchema _ = timeParamSchema "yyyy-mm-ddThh:MM:ss+hhMM"
+  toParamSchema _ = timeParamSchema "date-time"
 
 -- |
 -- >>> toParamSchema (Proxy :: Proxy UTCTime) ^. format

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -657,7 +657,7 @@ instance ToSchema LocalTime where
   declareNamedSchema _ = pure $ named "LocalTime" $ timeSchema "yyyy-mm-ddThh:MM:ss"
     & example ?~ toJSON (LocalTime (fromGregorian 2016 7 22) (TimeOfDay 7 40 0))
 
--- | Format @"date"@ corresponds to @yyyy-mm-ddThh:MM:ss(Z|+hh:MM)@ format.
+-- | Format @"date-time"@ corresponds to @yyyy-mm-ddThh:MM:ss(Z|+hh:MM)@ format.
 instance ToSchema ZonedTime where
   declareNamedSchema _ = pure $ named "ZonedTime" $ timeSchema "date-time"
     & example ?~ toJSON (ZonedTime (LocalTime (fromGregorian 2016 7 22) (TimeOfDay 7 40 0)) (hoursToTimeZone 3))


### PR DESCRIPTION
Previously ToParamSchema ZonedTime instance used custom format instead
of OpenAPI default "date-time".

Partially fixes #16.