### PR TITLE
Add sopSwaggerGenericToEncodingWithOpts and use it.

### DIFF
--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -48,6 +48,8 @@ import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 import Generics.SOP.TH                  (deriveGeneric)
 import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToJSON
                                         ,sopSwaggerGenericToJSONWithOpts
+                                        ,sopSwaggerGenericToEncoding
+                                        ,sopSwaggerGenericToEncodingWithOpts
                                         ,sopSwaggerGenericParseJSON
                                         ,HasSwaggerAesonOptions(..)
                                         ,AesonDefaultValue(..)
@@ -55,7 +57,6 @@ import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToJSON
                                         ,saoAdditionalPairs
                                         ,saoSubObject)
 import Data.OpenApi.Internal.Utils
-import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToEncoding)
 
 -- $setup
 -- >>> :seti -XDataKinds
@@ -1315,6 +1316,8 @@ instance ToJSON SecurityScheme where
 
 instance ToJSON Schema where
   toJSON = sopSwaggerGenericToJSONWithOpts $
+      mkSwaggerAesonOptions "schema" & saoSubObject ?~ "items"
+  toEncoding = sopSwaggerGenericToEncodingWithOpts $
       mkSwaggerAesonOptions "schema" & saoSubObject ?~ "items"
 
 instance ToJSON Header where

--- a/src/Data/OpenApi/Internal/AesonUtils.hs
+++ b/src/Data/OpenApi/Internal/AesonUtils.hs
@@ -9,8 +9,9 @@ module Data.OpenApi.Internal.AesonUtils (
     -- * Generic functions
     AesonDefaultValue(..),
     sopSwaggerGenericToJSON,
-    sopSwaggerGenericToEncoding,
     sopSwaggerGenericToJSONWithOpts,
+    sopSwaggerGenericToEncoding,
+    sopSwaggerGenericToEncodingWithOpts,
     sopSwaggerGenericParseJSON,
     -- * Options
     HasSwaggerAesonOptions(..),
@@ -266,6 +267,24 @@ sopSwaggerGenericToEncoding x =
   where
     proxy = Proxy :: Proxy a
     opts  = swaggerAesonOptions proxy
+
+sopSwaggerGenericToEncodingWithOpts
+    :: forall a xs.
+        ( HasDatatypeInfo a
+        , HasSwaggerAesonOptions a
+        , All2 ToJSON (Code a)
+        , All2 Eq (Code a)
+        , Code a ~ '[xs]
+        )
+    => SwaggerAesonOptions
+    -> a
+    -> Encoding
+sopSwaggerGenericToEncodingWithOpts opts x =
+    let ps = sopSwaggerGenericToEncoding' opts (from x) (datatypeInfo proxy) defs
+    in pairs (pairsToSeries (opts ^. saoAdditionalPairs) <> ps)
+  where
+    proxy = Proxy :: Proxy a
+    defs = hcpure (Proxy :: Proxy AesonDefaultValue) defaultValue
 
 pairsToSeries :: [Pair] -> Series
 pairsToSeries = foldMap (\(k, v) -> (k .= v))


### PR DESCRIPTION
The `ToJSON Schema` instance is missing an explicit definition of `toEncoding`. Without an explicit definition, the default definition kicks in, but the default loses ordering information of JSON object fields. This means that in resulting OpenAPI schemas, field names of JSON objects appear in essentially random order rather than the order specified in Haskell code.

The reason is that this `ToJSON` instance makes use of a somewhat special `sopSwaggerGenericToJSONWithOpts` function that is not used anywhere else and that had no counterpart for `Encoding`.

Such a counterpart is added here.

This is a relatively ad-hoc fix. This code looks like it might benefit from additional refactoring, but if at all, I think that should probably be done in a different MR.

See also haskell-servant/servant-swagger-ui#89 which is an orthogonal problem with losing the order of fields.