### PR TITLE
Use `SecurityDefinitions` type for `_componentsSecuritySchemes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Unreleased
 ----------
 
+- Use `SecurityDefinitions` type for `_componentsSecuritySchemes`
+  [#32](https://github.com/biocad/openapi3/pull/32)).
+
 3.1.0
 -----
 

--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -46,7 +46,8 @@ import           Data.HashMap.Strict.InsOrd (InsOrdHashMap)
 import qualified Data.HashMap.Strict.InsOrd as InsOrdHashMap
 
 import Generics.SOP.TH                  (deriveGeneric)
-import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToJSON
+import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToEncoding
+                                        ,sopSwaggerGenericToJSON
                                         ,sopSwaggerGenericToJSONWithOpts
                                         ,sopSwaggerGenericParseJSON
                                         ,HasSwaggerAesonOptions(..)
@@ -55,7 +56,6 @@ import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToJSON
                                         ,saoAdditionalPairs
                                         ,saoSubObject)
 import Data.OpenApi.Internal.Utils
-import Data.OpenApi.Internal.AesonUtils (sopSwaggerGenericToEncoding)
 
 -- $setup
 -- >>> :seti -XDataKinds
@@ -196,7 +196,7 @@ data Components = Components
   , _componentsExamples :: Definitions Example
   , _componentsRequestBodies :: Definitions RequestBody
   , _componentsHeaders :: Definitions Header
-  , _componentsSecuritySchemes :: Definitions SecurityScheme
+  , _componentsSecuritySchemes :: SecurityDefinitions
   , _componentsLinks :: Definitions Link
   , _componentsCallbacks :: Definitions Callback
   } deriving (Eq, Show, Generic, Data, Typeable)
@@ -1125,6 +1125,7 @@ instance SwaggerMonoid Response
 instance SwaggerMonoid ExternalDocs
 instance SwaggerMonoid Operation
 instance (Eq a, Hashable a) => SwaggerMonoid (InsOrdHashSet a)
+instance SwaggerMonoid SecurityDefinitions
 
 instance SwaggerMonoid MimeList
 deriving instance SwaggerMonoid URL
@@ -1614,3 +1615,5 @@ instance AesonDefaultValue MimeList where defaultValue = Just mempty
 instance AesonDefaultValue Info
 instance AesonDefaultValue ParamLocation
 instance AesonDefaultValue Link
+instance AesonDefaultValue SecurityDefinitions where
+  defaultValue = Just mempty

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -45,6 +45,10 @@ spec = do
         fromJSON petstoreExampleJSON `shouldSatisfy` (\x -> case x of Success (_ :: OpenApi) -> True; _ -> False)
       it "roundtrips: fmap toJSON . fromJSON" $ do
         (toJSON :: OpenApi -> Value) <$> fromJSON petstoreExampleJSON `shouldBe` Success petstoreExampleJSON
+    context "Security schemes" $ do
+      it "merged correctly" $ do
+        let merged = oAuth2SecurityDefinitionsReadOpenApi <> oAuth2SecurityDefinitionsWriteOpenApi
+        merged `shouldBe` oAuth2SecurityDefinitionsOpenApi
 
 main :: IO ()
 main = hspec spec
@@ -441,7 +445,7 @@ responsesDefinitionExampleJSON = [aesonQQ|
 |]
 
 -- =======================================================================
--- Responses Definition object
+-- Security Definition object
 -- =======================================================================
 
 securityDefinitionsExample :: SecurityDefinitions
@@ -526,6 +530,18 @@ oAuth2SecurityDefinitionsExampleJSON = [aesonQQ|
   }
 }
 |]
+
+oAuth2SecurityDefinitionsReadOpenApi :: OpenApi
+oAuth2SecurityDefinitionsReadOpenApi =
+  mempty & components . securitySchemes .~ oAuth2SecurityDefinitionsReadExample
+
+oAuth2SecurityDefinitionsWriteOpenApi :: OpenApi
+oAuth2SecurityDefinitionsWriteOpenApi =
+  mempty & components . securitySchemes .~ oAuth2SecurityDefinitionsWriteExample
+
+oAuth2SecurityDefinitionsOpenApi :: OpenApi
+oAuth2SecurityDefinitionsOpenApi =
+  mempty & components . securitySchemes .~ oAuth2SecurityDefinitionsExample
 
 -- =======================================================================
 -- Swagger object


### PR DESCRIPTION
Problem: there is `SecurityDefinitions` newtype which is unused.
Long ago it was used to store security schemas, but then in 821654c
the corresponding field changed to `Definitions SecurityScheme`.
There is one essential difference caused by this change: now if we
mappend two `Components` (or other types that hold `Components`
inside) and both sides have `SecuritySchemeOAuth2`, they won't be
merged.

Solution: change `_componentsSecuritySchemes` to `SecurityDefinitions`.

Resolves #30