### PR TITLE
WIP: Support GHC 9.2

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -2,3 +2,17 @@ packages: .
 tests: true
 
 allow-newer: http-media:base
+
+-- Temporary GHC 9.2 migration stuff (not intended to be merged to master)
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/generics-sop.git
+  tag: 58d7f2eab3a4f603fee50db27b2ad2f224881c9f
+  subdir: generics-sop
+
+source-repository-package
+  type: git
+  location: https://github.com/well-typed/generics-sop.git
+  tag: 58d7f2eab3a4f603fee50db27b2ad2f224881c9f
+  subdir: sop-core

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -58,11 +58,11 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.11.1.0  && <4.16
-    , bytestring       >=0.10.8.2  && <0.11
+      base             >=4.11.1.0  && <4.17
+    , bytestring       >=0.10.8.2  && <0.12
     , containers       >=0.5.11.0  && <0.7
-    , template-haskell >=2.13.0.0  && <2.18
-    , time             >=1.8.0.2   && <1.10
+    , template-haskell >=2.13.0.0  && <2.19
+    , time             >=1.8.0.2   && <1.13
     , transformers     >=0.5.5.0   && <0.6
 
   build-depends:
@@ -71,8 +71,8 @@ library
 
   -- other dependencies
   build-depends:
-      base-compat-batteries     >=0.11.1   && <0.12
-    , aeson                     >=1.4.2.0  && <1.6
+      base-compat-batteries     >=0.11.1   && <0.13
+    , aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && < 2.1
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.5
@@ -80,7 +80,7 @@ library
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.1
+    , lens                      >=4.16.1   && <5.2
     , network                   >=2.6.3.5  && <3.2
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5

--- a/test/SpecCommon.hs
+++ b/test/SpecCommon.hs
@@ -1,18 +1,25 @@
+{-# LANGUAGE CPP #-}
+
 module SpecCommon where
 
 import Data.Aeson
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as Key
+import qualified Data.Aeson.KeyMap as KeyMap
+#endif
 import Data.ByteString.Builder (toLazyByteString)
 import qualified Data.Foldable as F
 import qualified Data.HashMap.Strict as HashMap
+import           Data.Text (Text)
 import qualified Data.Vector as Vector
 
 import Test.Hspec
 
 isSubJSON :: Value -> Value -> Bool
 isSubJSON Null _ = True
-isSubJSON (Object x) (Object y) = HashMap.keys x == HashMap.keys i && F.and i
+isSubJSON (Object x) (Object y) = keysCompat x == keysCompat i && F.and i
   where
-    i = HashMap.intersectionWith isSubJSON x y
+    i = intersectionWithCompat isSubJSON x y
 isSubJSON (Array xs) (Array ys) = Vector.length xs == Vector.length ys && F.and (Vector.zipWith isSubJSON xs ys)
 isSubJSON x y = x == y
 
@@ -28,3 +35,28 @@ x <=> js = do
     eitherDecode (encode $ toJSON x) `shouldBe` Right x
   it "roundtrips with toEncoding" $ do
     eitherDecode (toLazyByteString $ fromEncoding $ toEncoding x) `shouldBe` Right x
+
+-------------------------------------------------------------------------------
+-- Aeson compatibility helpers
+-------------------------------------------------------------------------------
+
+#if MIN_VERSION_aeson(2,0,0)
+keysCompat :: KeyMap.KeyMap v -> [Text]
+keysCompat = map Key.toText . KeyMap.keys
+#else
+keysCompat :: HashMap.HashMap Text v -> [Text]
+keysCompat = HashMap.keys
+#endif
+
+#if MIN_VERSION_aeson(2,0,0)
+intersectionWithCompat ::
+  (a -> b -> c) -> KeyMap.KeyMap a -> KeyMap.KeyMap b -> KeyMap.KeyMap c
+intersectionWithCompat = KeyMap.intersectionWith
+#else
+intersectionWithCompat ::
+  (a -> b -> c) ->
+  HashMap.HashMap Text a ->
+  HashMap.HashMap Text b ->
+  HashMap.HashMap Text c
+intersectionWithCompat = HashMap.intersectionWith
+#endif


### PR DESCRIPTION
This PR attempts to add support for GHC 9.2 to `openapi3`.

The majority of the changes have to do with adding support for `aeson-2.0.*` while remaining compatible with `aeson-1.5.*` via CPP. The changes in this PR do not represent the best way to support `aeson-2.0.*` in `openapi3`, as I'm not sure what that would be, but I hope that this PR can provide a good starting point. I would be happy to extend this PR so that it meets this project's standards.

The `spec` test suite passes with all (compatible) combinations of GHC 8.10.7, 9.0.1, and 9.2.1 with aeson 1.5.* and 2.0.*.

Notably, the `doctest` test suite fails with a ghc panic on GHC 9.0.1 and 9.2.1. I'm not sure what to do about this.

Also, in case it might save a bit of your time, #881 of https://github.com/haskell/aeson/issues contains some guidance for migrating to `aeson-2`.