### PR TITLE
Allow text-2.0

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -70,7 +70,7 @@ library
 
   build-depends:
       mtl              >=2.2.2   && <2.3
-    , text             >=1.2.3.1 && <1.3
+    , text             >=1.2.3.1 && <2.1
 
   -- other dependencies
   build-depends:


### PR DESCRIPTION
Tested using

    cabal test --constraint='text>=2' -w ghc-9.0.2

This PR was requested on haskell-servant/servant/pull/1526.
