### PR TITLE
Support for external references

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -85,6 +85,7 @@ library
     , insert-ordered-containers >=0.2.3    && <0.3
     , lens                      >=4.16.1   && <5.2
     , network                   >=2.6.3.5  && <3.2
+    , network-uri               >=2.6.4.0  && <2.7
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -214,7 +214,7 @@ import Data.OpenApi.Internal
 --   & components . schemas .~ [ ("User", mempty & type_ ?~ OpenApiString) ]
 --   & paths .~
 --     [ ("/user", mempty & get ?~ (mempty
---         & at 200 ?~ ("OK" & _Inline.content.at "application/json" ?~ (mempty & schema ?~ Ref (Reference "User")))
+--         & at 200 ?~ ("OK" & _Inline.content.at "application/json" ?~ (mempty & schema ?~ Ref (InternalReference "User")))
 --         & at 404 ?~ "User info not found")) ]
 -- :}
 -- {

--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -44,6 +44,7 @@ import           GHC.Generics          (Generic)
 import           Network.HTTP.Media    (MediaType, mainType, parameters, parseAccept, subType, (//),
                                         (/:))
 import           Network.Socket        (HostName, PortNumber)
+import           Network.URI           (URI, parseURIReference, uriToString)
 import           Text.Read             (readMaybe)
 
 import           Data.HashMap.Strict.InsOrd (InsOrdHashMap)
@@ -943,8 +944,13 @@ data ExternalDocs = ExternalDocs
 instance Hashable ExternalDocs
 
 -- | A simple object to allow referencing other definitions in the specification.
--- It can be used to reference parameters and responses that are defined at the top level for reuse.
-newtype Reference = Reference { getReference :: Text }
+-- It can be used to reference parameters and responses that are defined at the top level for reuse
+-- or for referencing definitions from external schemas via a URI.
+data Reference 
+  = -- | For referencing definitions from within the current OpenAPI schema.
+    InternalReference Text
+    -- | For referencing definitions from external schemas.
+  | ExternalReference URI
   deriving (Eq, Show, Data, Typeable)
 
 data Referenced a
@@ -1392,10 +1398,12 @@ instance ToJSON SecurityDefinitions where
   toJSON (SecurityDefinitions sd) = toJSON sd
 
 instance ToJSON Reference where
-  toJSON (Reference ref) = object [ "$ref" .= ref ]
+  toJSON (InternalReference ref) = object [ "$ref" .= ref ]
+  toJSON (ExternalReference uri) = object [ "$ref" .= uriToString id uri "" ]
 
 referencedToJSON :: ToJSON a => Text -> Referenced a -> Value
-referencedToJSON prefix (Ref (Reference ref)) = object [ "$ref" .= (prefix <> ref) ]
+referencedToJSON prefix (Ref (InternalReference ref)) = object [ "$ref" .= (prefix <> ref) ]
+referencedToJSON prefix (Ref (ExternalReference uri)) = object [ "$ref" .= uriToString id uri "" ]
 referencedToJSON _ (Inline x) = toJSON x
 
 instance ToJSON (Referenced Schema)   where toJSON = referencedToJSON "#/components/schemas/"
@@ -1523,7 +1531,14 @@ instance FromJSON Link where
   parseJSON = sopSwaggerGenericParseJSON
 
 instance FromJSON Reference where
-  parseJSON (Object o) = Reference <$> o .: "$ref"
+  parseJSON (Object o) = do 
+    ref <- o .: "$ref"
+    if "#" `Text.isPrefixOf` ref 
+      then pure $ InternalReference ref
+      else 
+        let refError = fail "expected $ref to be either a URI or a fragment"
+         in maybe refError (pure . ExternalReference) . parseURIReference $ Text.unpack ref
+
   parseJSON _ = empty
 
 referencedParseJSON :: FromJSON a => Text -> Value -> JSON.Parser (Referenced a)
@@ -1535,8 +1550,10 @@ referencedParseJSON prefix js@(Object o) = do
   where
     parseRef s = do
       case Text.stripPrefix prefix s of
-        Nothing     -> fail $ "expected $ref of the form \"" <> Text.unpack prefix <> "*\", but got " <> show s
-        Just suffix -> pure (Reference suffix)
+        Nothing -> 
+          let refError = fail $ "expected $ref to be either a URI, or of the form \"" <> Text.unpack prefix <> "*\", but got " <> show s
+           in maybe refError (pure . ExternalReference) . parseURIReference $ Text.unpack s
+        Just suffix -> pure (InternalReference suffix)
 referencedParseJSON _ _ = fail "referenceParseJSON: not an object"
 
 instance FromJSON (Referenced Schema)   where parseJSON = referencedParseJSON "#/components/schemas/"

--- a/src/Data/OpenApi/Lens.hs
+++ b/src/Data/OpenApi/Lens.hs
@@ -63,6 +63,8 @@ makeFields ''Link
 makePrisms ''SecuritySchemeType
 -- ** 'Referenced' prisms
 makePrisms ''Referenced
+-- ** 'Reference prisms
+makePrisms ''Reference
 
 -- ** 'OpenApiItems' prisms
 

--- a/src/Data/OpenApi/Operation.hs
+++ b/src/Data/OpenApi/Operation.hs
@@ -298,8 +298,9 @@ setResponseForWith ops f code dres swag = swag
   where
     (defs, new) = runDeclare dres mempty
 
-    combine (Just (Ref (Reference n))) = case swag ^. components.responses.at n of
+    combine (Just (Ref (InternalReference n))) = case swag ^. components.responses.at n of
       Just old -> f old new
       Nothing  -> new -- response name can't be dereferenced, replacing with new response
+    combine (Just (Ref (ExternalReference uri))) = new -- external reference can't be dereferenced, just replace with new
     combine (Just (Inline old)) = f old new
     combine Nothing = new

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -26,7 +26,7 @@
 --   & #components % #schemas .~ [ ("User", mempty & #type ?~ OpenApiString) ]
 --   & #paths .~
 --     [ ("/user", mempty & #get ?~ (mempty
---         & at 200 ?~ ("OK" & #_Inline % #content % at "application/json" ?~ (mempty & #schema ?~ Ref (Reference "User")))
+--         & at 200 ?~ ("OK" & #_Inline % #content % at "application/json" ?~ (mempty & #schema ?~ Ref (InternalReference "User")))
 --         & at 404 ?~ "User info not found")) ]
 -- :}
 -- {

--- a/src/Data/OpenApi/Schema/Generator.hs
+++ b/src/Data/OpenApi/Schema/Generator.hs
@@ -100,8 +100,9 @@ schemaGen defns schema =
           return . Object $ fromInsOrdHashMap x
 
 dereference :: Definitions a -> Referenced a -> a
-dereference _ (Inline a)               = a
-dereference defs (Ref (Reference ref)) = fromJust $ M.lookup ref defs
+dereference _ (Inline a)                       = a
+dereference defs (Ref (InternalReference ref)) = fromJust $ M.lookup ref defs
+dereference defs (Ref (ExternalReference ref)) = error $ "can't dereference external reference: " <> show ref
 
 genValue :: (ToSchema a) => Proxy a -> Gen Value
 genValue p =

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -229,7 +229,7 @@ schemaSimpleModelExample = mempty
   & required .~ [ "name" ]
   & properties .~
       [ ("name", Inline (mempty & type_ ?~ OpenApiString))
-      , ("address", Ref (Reference "Address"))
+      , ("address", Ref (InternalReference "Address"))
       , ("age", Inline $ mempty
             & minimum_ ?~ 0
             & type_    ?~ OpenApiInteger
@@ -935,7 +935,7 @@ compositionSchemaExample :: Schema
 compositionSchemaExample = mempty
   & type_ ?~ OpenApiObject
   & Data.OpenApi.allOf ?~ [
-      Ref (Reference "Other")
+      Ref (InternalReference "Other")
     , Inline (mempty
              & type_ ?~ OpenApiObject
              & properties .~


### PR DESCRIPTION
In an OpenAPI spec I'm trying to define, I need to be able to `$ref` out to Schemas defined in another OpenAPI contract. I'm trying to reuse some Schema types from that contract without having to inline them into my contract. According to the OpenAPI spec (as far as I understand it), this is supported, since JSON References are URIs that can be absolute or relative and therefore can be pointed to an external file. 

Unfortunately, `openapi3` treats References like names to entities defined within the current OpenAPI contract. This is fine if all your entities are defined wholly within your own contract, but if you want to reference things externally, you can't.

An example external reference URI is: `https://raw.githubusercontent.com/OAI/OpenAPI-Specification/80c781e479f85ac67001ceb3e7e410e25d2a561b/schemas/v3.0/schema.json#/definitions/Schema` (a reference to the schema of OpenAPI's Schema 😉)

This PR is an attempt to solve this by modifying the Reference newtype and changing it into a sum type:
```haskell
data Reference 
  = InternalReference Text
  | ExternalReference URI
```

InternalReferences are handled with exactly the same behaviour as the old newtype Reference. ExternalReferences are basically treated opaquely and the URI within them in simply serialized/deserialized to JSON verbatim.

I'm not sure if this is necessarily the right approach to solve the problem, but I thought I'd submit it as food for thought and see what you thought about it. There are a couple of disadvantages:
* It's a big breaking change to the Reference type
* ExternalReferences are still kinda poorly supported, in that code that would have previously looked up a reference from a Definitions set, such as validation, just barfs on them. To fix this would require introducing IO to be able to load the external reference, and the ability to deserialize arbitrary JSON schema docs. However, one could argue that at least with this approach External References are somewhat supported, as opposed to right now, where they 100% don't work. 🤷‍♂️