### PR TITLE
Don't add 'object' type when generating sum schema with allOf/oneOf

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -84,7 +84,6 @@ library
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
     , lens                      >=4.16.1   && <5.2
-    , network                   >=2.6.3.5  && <3.2
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -409,8 +409,7 @@ import Data.OpenApi.Internal
 --             ],
 --             "type": "object"
 --         }
---     ],
---     "type": "object"
+--     ]
 -- }
 
 -- $manipulation

--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -43,7 +43,6 @@ import           Data.Text.Encoding    (encodeUtf8)
 import           GHC.Generics          (Generic)
 import           Network.HTTP.Media    (MediaType, mainType, parameters, parseAccept, subType, (//),
                                         (/:))
-import           Network.Socket        (HostName, PortNumber)
 import           Text.Read             (readMaybe)
 
 import           Data.HashMap.Strict.InsOrd (InsOrdHashMap)

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -1026,7 +1026,6 @@ gdeclareNamedSumSchema opts proxy _
   | otherwise = do
     (schemas, _) <- runWriterT declareSumSchema
     return $ unnamed $ mempty
-      & type_ ?~ OpenApiObject
       & oneOf ?~ (snd <$> schemas)
   where
     declareSumSchema = gsumToSchema opts proxy
@@ -1071,7 +1070,6 @@ gsumConToSchemaWith ref opts _ = (tag, schema)
 
           -- In the remaining cases we combine "tag" object and "contents" object using allOf.
           _ -> Inline $ mempty
-            & type_ ?~ OpenApiObject
             & allOf ?~ [Inline $ mempty
               & type_ ?~ OpenApiObject
               & required .~ (T.pack tagField : if isRecord then [] else [T.pack contentsField])

--- a/test/Data/OpenApi/CommonTestTypes.hs
+++ b/test/Data/OpenApi/CommonTestTypes.hs
@@ -312,8 +312,7 @@ characterSchemaJSON = [aesonQQ|
         }
       }
     }
-  ],
-  "type": "object"
+  ]
 }
 
 |]
@@ -398,8 +397,7 @@ characterInlinedSchemaJSON = [aesonQQ|
         }
       }
     }
-  ],
-  "type": "object"
+  ]
 }
 |]
 
@@ -455,8 +453,7 @@ characterInlinedPlayerSchemaJSON = [aesonQQ|
         }
       }
     }
-  ],
-  "type": "object"
+  ]
 }
 |]
 
@@ -705,8 +702,7 @@ lightSchemaJSON = [aesonQQ|
         }
       }
     }
-  ],
-  "type": "object"
+  ]
 }
 |]
 
@@ -789,8 +785,7 @@ lightInlinedSchemaJSON = [aesonQQ|
         }
       }
     }
-  ],
-  "type": "object"
+  ]
 }
 |]
 
@@ -929,8 +924,7 @@ predicateSchemaDeclareJSON = [aesonQQ|
           "required": ["tag", "contents"],
           "type": "object"
         }
-      ],
-      "type": "object"
+      ]
     },
     "Noun": {
       "properties": {
@@ -969,8 +963,7 @@ predicateSchemaDeclareJSON = [aesonQQ|
           "required": ["tag", "contents"],
           "type": "object"
         }
-      ],
-      "type": "object"
+      ]
     },
     "Omitted": {
       "properties": {

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -933,7 +933,6 @@ petstoreExampleJSON = [aesonQQ|
 
 compositionSchemaExample :: Schema
 compositionSchemaExample = mempty
-  & type_ ?~ OpenApiObject
   & Data.OpenApi.allOf ?~ [
       Ref (Reference "Other")
     , Inline (mempty
@@ -946,7 +945,6 @@ compositionSchemaExample = mempty
 compositionSchemaExampleJSON :: Value
 compositionSchemaExampleJSON = [aesonQQ|
 {
-  "type": "object",
   "allOf": [
       {
          "$ref": "#/components/schemas/Other"


### PR DESCRIPTION
When generating schema for some sum types the `type` field is set as `object`. But that seems to be incorrect. E.g.
``` haskell
data Foo = Bar | Baz Int
  deriving (Show, Generic)
instance ToSchema Foo where
  declareNamedSchema = genericDeclareNamedSchema defaultSchemaOptions{sumEncoding = UntaggedValue}
```
will have schema
``` json
{
    "oneOf": [
        {
            "enum": [
                "Bar"
            ],
            "type": "string"
        },
        {
            "maximum": 9223372036854775807,
            "minimum": -9223372036854775808,
            "type": "integer"
        }
    ],
    "type": "object"
} 
```
However, encoding of the Foo is clearly not an object.

This also confuses SwaggerUI.

Schema is valid
![image](https://user-images.githubusercontent.com/19261863/167827645-29013e50-9d86-475a-b65f-2b466996b834.png)

But generated example is not
![image](https://user-images.githubusercontent.com/19261863/167827746-146c3109-8d52-4321-ad46-bac8e44937ff.png)

If one removes `type` field example becomes valid
![image](https://user-images.githubusercontent.com/19261863/167828039-ab9ae6ae-99c5-4c96-90c8-03ad60f4f3c9.png)

Unrelated change, but looks like there was a redundant dependency on `network` package. Few types from it were imported, but neither used nor re-exported.