### PR TITLE
Updated for doctest on GHC 9.4

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -148,6 +148,7 @@ test-suite doctests
   hs-source-dirs:   test
   main-is:          doctests.hs
   type:             exitcode-stdio-1.0
+  build-depends:    base, openapi3
 
 executable example
   hs-source-dirs:   examples

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -137,7 +137,10 @@ import Data.OpenApi.Internal
 -- >>> import Data.Proxy
 -- >>> import GHC.Generics
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSL
+-- >>> import Data.OpenApi.Internal
+-- >>> import Data.OpenApi.Internal.Schema
 -- >>> import Data.OpenApi.Internal.Utils
+-- >>> import Data.OpenApi.Lens
 -- >>> :set -XDeriveGeneric
 -- >>> :set -XOverloadedStrings
 -- >>> :set -XOverloadedLists
@@ -213,7 +216,7 @@ import Data.OpenApi.Internal
 -- BSL.putStrLn $ encodePretty $ (mempty :: OpenApi)
 --   & components . schemas .~ [ ("User", mempty & type_ ?~ OpenApiString) ]
 --   & paths .~
---     [ ("/user", mempty & get ?~ (mempty
+--     [ ("/user", mempty & Data.OpenApi.Lens.get ?~ (mempty
 --         & at 200 ?~ ("OK" & _Inline.content.at "application/json" ?~ (mempty & schema ?~ Ref (Reference "User")))
 --         & at 404 ?~ "User info not found")) ]
 -- :}

--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -139,11 +139,11 @@ import Data.OpenApi.Internal
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSL
 -- >>> import Data.OpenApi.Internal
 -- >>> import Data.OpenApi.Internal.Schema
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 -- >>> import Data.OpenApi.Internal.Utils
 -- >>> import Data.OpenApi.Lens
 -- >>> :set -XDeriveGeneric
 -- >>> :set -XOverloadedStrings
--- >>> :set -XOverloadedLists
 -- >>> :set -fno-warn-missing-methods
 
 -- $howto
@@ -214,9 +214,9 @@ import Data.OpenApi.Internal
 --
 -- >>> :{
 -- BSL.putStrLn $ encodePretty $ (mempty :: OpenApi)
---   & components . schemas .~ [ ("User", mempty & type_ ?~ OpenApiString) ]
+--   & components . schemas .~ IOHM.fromList [ ("User", mempty & type_ ?~ OpenApiString) ]
 --   & paths .~
---     [ ("/user", mempty & Data.OpenApi.Lens.get ?~ (mempty
+--     IOHM.fromList [ ("/user", mempty & get ?~ (mempty
 --         & at 200 ?~ ("OK" & _Inline.content.at "application/json" ?~ (mempty & schema ?~ Ref (Reference "User")))
 --         & at 404 ?~ "User info not found")) ]
 -- :}

--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -92,6 +92,13 @@ unname (NamedSchema _ schema) = unnamed schema
 rename :: Maybe T.Text -> NamedSchema -> NamedSchema
 rename name (NamedSchema _ schema) = NamedSchema name schema
 
+-- $setup
+-- >>> import Data.Aeson.Types (toJSONKeyText)
+-- >>> import qualified Data.ByteString.Lazy.Char8 as BSL
+-- >>> import Data.OpenApi.Internal
+-- >>> import Data.OpenApi.Internal.Utils (encodePretty)
+-- >>> import Data.OpenApi.Lens (name, schema)
+
 -- | Convert a type into @'Schema'@.
 --
 -- An example type and instance:

--- a/src/Data/OpenApi/Internal/Schema/Validation.hs
+++ b/src/Data/OpenApi/Internal/Schema/Validation.hs
@@ -59,6 +59,9 @@ import Data.OpenApi.Internal.Schema
 import Data.OpenApi.Internal.Utils
 import Data.OpenApi.Lens
 
+-- $setup
+-- >>> import Data.OpenApi.Internal.Schema.Validation
+
 -- | Validate @'ToJSON'@ instance matches @'ToSchema'@ for a given value.
 -- This can be used with QuickCheck to ensure those instances are coherent:
 --

--- a/src/Data/OpenApi/Operation.hs
+++ b/src/Data/OpenApi/Operation.hs
@@ -55,12 +55,13 @@ import qualified Data.HashSet.InsOrd as InsOrdHS
 -- >>> import Data.Proxy
 -- >>> import Data.Time
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSL
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 -- >>> import Data.OpenApi.Internal.Utils
 
 -- | Prepend path piece to all operations of the spec.
 -- Leading and trailing slashes are trimmed/added automatically.
 --
--- >>> let api = (mempty :: OpenApi) & paths .~ [("/info", mempty)]
+-- >>> let api = (mempty :: OpenApi) & paths .~ IOHM.fromList [("/info", mempty)]
 -- >>> BSL.putStrLn $ encodePretty $ prependPath "user/{user_id}" api ^. paths
 -- {
 --     "/user/{user_id}/info": {}
@@ -83,8 +84,8 @@ allOperations = paths.traverse.template
 -- by both path and method.
 --
 -- >>> let ok = (mempty :: Operation) & at 200 ?~ "OK"
--- >>> let api = (mempty :: OpenApi) & paths .~ [("/user", mempty & get ?~ ok & post ?~ ok)]
--- >>> let sub = (mempty :: OpenApi) & paths .~ [("/user", mempty & get ?~ mempty)]
+-- >>> let api = (mempty :: OpenApi) & paths .~ IOHM.fromList [("/user", mempty & get ?~ ok & post ?~ ok)]
+-- >>> let sub = (mempty :: OpenApi) & paths .~ IOHM.fromList [("/user", mempty & get ?~ mempty)]
 -- >>> BSL.putStrLn $ encodePretty api
 -- {
 --     "components": {},
@@ -215,7 +216,7 @@ declareResponse cType proxy = do
 --
 -- Example:
 --
--- >>> let api = (mempty :: OpenApi) & paths .~ [("/user", mempty & get ?~ mempty)]
+-- >>> let api = (mempty :: OpenApi) & paths .~ IOHM.fromList [("/user", mempty & get ?~ mempty)]
 -- >>> let res = declareResponse "application/json" (Proxy :: Proxy Day)
 -- >>> BSL.putStrLn $ encodePretty $ api & setResponse 200 res
 -- {

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -18,14 +18,15 @@
 -- >>> import Optics.Core
 -- >>> :set -XOverloadedLabels
 -- >>> import qualified Data.ByteString.Lazy.Char8 as BSL
+-- >>> import qualified Data.HashMap.Strict.InsOrd as IOHM
 --
 -- Example from the "Data.OpenApi" module using @optics@:
 --
 -- >>> :{
 -- BSL.putStrLn $ encodePretty $ (mempty :: OpenApi)
---   & #components % #schemas .~ [ ("User", mempty & #type ?~ OpenApiString) ]
+--   & #components % #schemas .~ IOHM.fromList [ ("User", mempty & #type ?~ OpenApiString) ]
 --   & #paths .~
---     [ ("/user", mempty & #get ?~ (mempty
+--     IOHM.fromList [ ("/user", mempty & #get ?~ (mempty
 --         & at 200 ?~ ("OK" & #_Inline % #content % at "application/json" ?~ (mempty & #schema ?~ Ref (Reference "User")))
 --         & at 404 ?~ "User info not found")) ]
 -- :}


### PR DESCRIPTION
Fixes

* https://github.com/commercialhaskell/stackage/issues/6678
* https://github.com/commercialhaskell/stackage/issues/6624
* https://github.com/commercialhaskell/stackage/issues/6615

Tested using

    cabal test --enable-tests -w ghc-9.4.2 --constraint='vector>=0.13' --constraint='lens>=5.2' --constraint='aeson>=2.1'

~~The tests can't be run because doctest doesn't support GHC 9.4 yet.~~