### PR TITLE
Bump lens upper bound to include 5.2

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -83,7 +83,7 @@ library
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.2
+    , lens                      >=4.16.1   && <5.3
     , network                   >=2.6.3.5  && <3.2
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5


### PR DESCRIPTION
Tested with `cabal test --constraint 'lens == 5.2'` like the previous bump in https://github.com/biocad/openapi3/pull/36