### PR TITLE
Fix bug parsing set of valid OpenApi spec versions

### DIFF
--- a/src/Data/OpenApi/Internal.hs
+++ b/src/Data/OpenApi/Internal.hs
@@ -103,9 +103,17 @@ data OpenApi = OpenApi
     -- | Additional external documentation.
   , _openApiExternalDocs :: Maybe ExternalDocs
 
-  , -- | The spec of OpenApi this spec adheres to. Must be between 3.0.0 and 3.0.3
+  , -- | The spec of OpenApi this spec adheres to. Must be between 'lowerOpenApiSpecVersion' and 'upperOpenApiSpecVersion'
     _openApiOpenapi :: OpenApiSpecVersion
   } deriving (Eq, Show, Generic, Data, Typeable)
+
+-- | This is the lower version of the OpenApi Spec this library can parse or produce
+lowerOpenApiSpecVersion :: Version
+lowerOpenApiSpecVersion = makeVersion [3, 0, 0]
+
+-- | This is the upper version of the OpenApi Spec this library can parse or produce
+upperOpenApiSpecVersion :: Version
+upperOpenApiSpecVersion = makeVersion [3, 0, 3]
 
 -- | The object provides metadata about the API.
 -- The metadata MAY be used by the clients if needed,
@@ -1450,9 +1458,8 @@ instance FromJSON OpenApiSpecVersion where
             let validatedVersion :: Either String Version
                 validatedVersion = do
                   parsedVersion <- readVersion str 
-                  upperBound <- readVersion "3.0.3" -- Latest known version that works with the spec
-                  lowerBound <- readVersion "3.0.0"
-                  unless ((parsedVersion >= lowerBound) && (parsedVersion <= upperBound)) $ Left ("The provided version " <> showVersion parsedVersion <> " is out of the allowed range >=3.0.0 && <=3.0.3")
+                  unless ((parsedVersion >= lowerOpenApiSpecVersion) && (parsedVersion <= upperOpenApiSpecVersion)) $
+                     Left ("The provided version " <> showVersion parsedVersion <> " is out of the allowed range >=" <> showVersion lowerOpenApiSpecVersion <> " && <=" <> showVersion upperOpenApiSpecVersion)
                   return parsedVersion
              in 
               either fail (return . OpenApiSpecVersion) validatedVersion

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -39,7 +39,10 @@ spec = do
   describe "OAuth2 Security Definitions with empty Scope" $ oAuth2SecurityDefinitionsEmptyExample <=> oAuth2SecurityDefinitionsEmptyExampleJSON
   describe "Composition Schema Example" $ compositionSchemaExample <=> compositionSchemaExampleJSON
   describe "Swagger Object" $ do
-    context "Example with no paths" $ emptyPathsFieldExample <=> emptyPathsFieldExampleJSON
+    context "Example with no paths" $ do 
+      emptyPathsFieldExample <=> emptyPathsFieldExampleJSON
+      it "fails to parse a spec with a wrong Openapi spec version" $ do
+        (fromJSON wrongVersionExampleJSON :: Result OpenApi) `shouldBe` Error "The provided version 3.0.4 is out of the allowed range >=3.0.0 && <=3.0.3"
     context "Todo Example" $ swaggerExample <=> swaggerExampleJSON
     context "PetStore Example" $ do
       it "decodes successfully" $ do
@@ -582,6 +585,16 @@ oAuth2SecurityDefinitionsOpenApi =
 emptyPathsFieldExample :: OpenApi
 emptyPathsFieldExample = mempty
 
+wrongVersionExampleJSON :: Value
+wrongVersionExampleJSON = [aesonQQ|
+{
+  "openapi": "3.0.4",
+  "info": {"version": "", "title": ""},
+  "paths": {},
+  "components": {}
+}
+|]
+
 emptyPathsFieldExampleJSON :: Value
 emptyPathsFieldExampleJSON = [aesonQQ|
 {
@@ -695,7 +708,7 @@ swaggerExampleJSON = [aesonQQ|
 petstoreExampleJSON :: Value
 petstoreExampleJSON = [aesonQQ|
 {
-  "openapi": "3.0.0",
+  "openapi": "3.0.3",
   "info": {
     "version": "1.0.0",
     "title": "Swagger Petstore",


### PR DESCRIPTION
The library was lacking the mandatory field `openapi` as a root element. This wasn't required before because version was fixed at `3.0.0`. This PR is intended to allow parsing all versions in the `3.0.x` range and closes #64 