### PR TITLE
Adds missing type-family & type-class instances for SecuirtyDefinitions type to make it work with indexed lenses

### DIFF
--- a/src/Data/OpenApi/Lens.hs
+++ b/src/Data/OpenApi/Lens.hs
@@ -104,6 +104,11 @@ instance HasType NamedSchema (Maybe OpenApiType) where type_ = schema.type_
 -- Type family instances for SecurityDefinitions type
 type instance Index SecurityDefinitions = Text
 type instance IxValue SecurityDefinitions = SecurityScheme
+
+-- Type-Class instances for SecurityDefinitions type
+instance Ixed SecurityDefinitions where ix n = (coerced :: Lens' SecurityDefinitions (Definitions SecurityScheme)). ix n
+instance At   SecurityDefinitions where at n = (coerced :: Lens' SecurityDefinitions (Definitions SecurityScheme)). at n
+
 -- OVERLAPPABLE instances
 
 instance


### PR DESCRIPTION
Hi,

This PR addresses issues #76 and #77 

It makes the `SecurityDefinition` indexable via the "at" or "ix" lenses / traversals .

It was missing a few type-family and type-class instances, which have been added in this PR.