### PR TITLE
Support top-level references in components

### DIFF
--- a/src/Data/OpenApi.hs
+++ b/src/Data/OpenApi.hs
@@ -214,7 +214,7 @@ import Data.OpenApi.Internal
 --
 -- >>> :{
 -- BSL.putStrLn $ encodePretty $ (mempty :: OpenApi)
---   & components . schemas .~ IOHM.fromList [ ("User", mempty & type_ ?~ OpenApiString) ]
+--   & components . schemas .~ IOHM.fromList [ ("User", Inline $ mempty & type_ ?~ OpenApiString) ]
 --   & paths .~
 --     IOHM.fromList [ ("/user", mempty & get ?~ (mempty
 --         & at 200 ?~ ("OK" & _Inline.content.at "application/json" ?~ (mempty & schema ?~ Ref (Reference "User")))

--- a/src/Data/OpenApi/Internal/Schema/Validation.hs
+++ b/src/Data/OpenApi/Internal/Schema/Validation.hs
@@ -299,7 +299,8 @@ withRef :: Reference -> (Schema -> Validation s a) -> Validation s a
 withRef (Reference ref) f = withConfig $ \cfg ->
   case InsOrdHashMap.lookup ref (configDefinitions cfg) of
     Nothing -> invalid $ "unknown schema " ++ show ref
-    Just s  -> f s
+    Just (Ref ref') -> invalid $ "reference to a reference is currently unsupported: " ++ show ref ++ " refers to the reference " ++ show ref'
+    Just (Inline s)  -> f s
 
 validateWithSchemaRef :: Referenced Schema -> Value -> Validation s ()
 validateWithSchemaRef (Ref ref)  js = withRef ref $ \sch -> sub sch (validateWithSchema js)

--- a/src/Data/OpenApi/Operation.hs
+++ b/src/Data/OpenApi/Operation.hs
@@ -300,7 +300,8 @@ setResponseForWith ops f code dres swag = swag
     (defs, new) = runDeclare dres mempty
 
     combine (Just (Ref (Reference n))) = case swag ^. components.responses.at n of
-      Just old -> f old new
+      Just (Inline old) -> f old new
+      Just (Ref _) -> new -- we don't chase references any further, to avoid a loop in case of recursion
       Nothing  -> new -- response name can't be dereferenced, replacing with new response
     combine (Just (Inline old)) = f old new
     combine Nothing = new

--- a/src/Data/OpenApi/Optics.hs
+++ b/src/Data/OpenApi/Optics.hs
@@ -24,7 +24,7 @@
 --
 -- >>> :{
 -- BSL.putStrLn $ encodePretty $ (mempty :: OpenApi)
---   & #components % #schemas .~ IOHM.fromList [ ("User", mempty & #type ?~ OpenApiString) ]
+--   & #components % #schemas .~ IOHM.fromList [ ("User", Inline $ mempty & #type ?~ OpenApiString) ]
 --   & #paths .~
 --     IOHM.fromList [ ("/user", mempty & #get ?~ (mempty
 --         & at 200 ?~ ("OK" & #_Inline % #content % at "application/json" ?~ (mempty & #schema ?~ Ref (Reference "User")))

--- a/src/Data/OpenApi/Schema/Generator.hs
+++ b/src/Data/OpenApi/Schema/Generator.hs
@@ -101,7 +101,10 @@ schemaGen defns schema =
 
 dereference :: Definitions a -> Referenced a -> a
 dereference _ (Inline a)               = a
-dereference defs (Ref (Reference ref)) = fromJust $ M.lookup ref defs
+dereference defs (Ref (Reference ref)) = fromInline $ fromJust $ M.lookup ref defs
+  where
+    fromInline (Inline s) = s
+    fromInline (Ref _) = error "reference to another reference is unsupported"
 
 genValue :: (ToSchema a) => Proxy a -> Gen Value
 genValue p =

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -39,7 +39,7 @@ spec = do
   describe "OAuth2 Security Definitions with empty Scope" $ oAuth2SecurityDefinitionsEmptyExample <=> oAuth2SecurityDefinitionsEmptyExampleJSON
   describe "Composition Schema Example" $ compositionSchemaExample <=> compositionSchemaExampleJSON
   describe "Swagger Object" $ do
-    context "Example with no paths" $ do 
+    context "Example with no paths" $ do
       emptyPathsFieldExample <=> emptyPathsFieldExampleJSON
       it "fails to parse a spec with a wrong Openapi spec version" $ do
         (fromJSON wrongVersionExampleJSON :: Result OpenApi) `shouldBe` Error "The provided version 3.0.4 is out of the allowed range >=3.0.0 && <=3.0.3"
@@ -49,6 +49,11 @@ spec = do
         fromJSON petstoreExampleJSON `shouldSatisfy` (\x -> case x of Success (_ :: OpenApi) -> True; _ -> False)
       it "roundtrips: fmap toJSON . fromJSON" $ do
         (toJSON :: OpenApi -> Value) <$> fromJSON petstoreExampleJSON `shouldBe` Success petstoreExampleJSON
+    context "Ref schema example" $ do
+      it "decodes successfully" $ do
+        fromJSON refSchemaExampleJSON `shouldSatisfy` (\x -> case x of Success (_ :: OpenApi) -> True; _ -> False)
+      it "roundtrips: fmap toJSON . fromJSON" $ do
+        (toJSON :: OpenApi -> Value) <$> fromJSON refSchemaExampleJSON `shouldBe` Success refSchemaExampleJSON
     context "Security schemes" $ do
       it "merged correctly" $ do
         let merged = oAuth2SecurityDefinitionsReadOpenApi <> oAuth2SecurityDefinitionsWriteOpenApi <> oAuth2SecurityDefinitionsEmptyOpenApi
@@ -454,17 +459,17 @@ responsesDefinitionExampleJSON = [aesonQQ|
 
 securityDefinitionsExample :: SecurityDefinitions
 securityDefinitionsExample = SecurityDefinitions
-  [ ("api_key", SecurityScheme
+  [ ("api_key", Inline (SecurityScheme
       { _securitySchemeType = SecuritySchemeApiKey (ApiKeyParams "api_key" ApiKeyHeader)
-      , _securitySchemeDescription = Nothing })
-  , ("petstore_auth", SecurityScheme
+      , _securitySchemeDescription = Nothing }))
+  , ("petstore_auth", Inline (SecurityScheme
       { _securitySchemeType = SecuritySchemeOAuth2 (mempty & implicit ?~ OAuth2Flow
             { _oAuth2Params = OAuth2ImplicitFlow "http://swagger.io/api/oauth/dialog"
             , _oAath2RefreshUrl = Nothing
             , _oAuth2Scopes =
                 [ ("write:pets",  "modify pets in your account")
                 , ("read:pets", "read your pets") ] } )
-      , _securitySchemeDescription = Nothing }) ]
+      , _securitySchemeDescription = Nothing })) ]
 
 securityDefinitionsExampleJSON :: Value
 securityDefinitionsExampleJSON = [aesonQQ|
@@ -492,35 +497,35 @@ securityDefinitionsExampleJSON = [aesonQQ|
 
 oAuth2SecurityDefinitionsReadExample :: SecurityDefinitions
 oAuth2SecurityDefinitionsReadExample = SecurityDefinitions
-  [ ("petstore_auth", SecurityScheme
+  [ ("petstore_auth", Inline (SecurityScheme
       { _securitySchemeType = SecuritySchemeOAuth2 (mempty & implicit ?~ OAuth2Flow
             { _oAuth2Params = OAuth2ImplicitFlow "http://swagger.io/api/oauth/dialog"
             , _oAath2RefreshUrl = Nothing
             , _oAuth2Scopes =
               [ ("read:pets", "read your pets") ] } )
-      , _securitySchemeDescription = Nothing })
+      , _securitySchemeDescription = Nothing }))
   ]
 
 oAuth2SecurityDefinitionsWriteExample :: SecurityDefinitions
 oAuth2SecurityDefinitionsWriteExample = SecurityDefinitions
-  [ ("petstore_auth", SecurityScheme
+  [ ("petstore_auth", Inline (SecurityScheme
       { _securitySchemeType = SecuritySchemeOAuth2 (mempty & implicit ?~ OAuth2Flow
             { _oAuth2Params = OAuth2ImplicitFlow "http://swagger.io/api/oauth/dialog"
             , _oAath2RefreshUrl = Nothing
             , _oAuth2Scopes =
                 [ ("write:pets", "modify pets in your account") ] } )
-      , _securitySchemeDescription = Nothing })
+      , _securitySchemeDescription = Nothing }))
   ]
 
 oAuth2SecurityDefinitionsEmptyExample :: SecurityDefinitions
 oAuth2SecurityDefinitionsEmptyExample = SecurityDefinitions
-  [ ("petstore_auth", SecurityScheme
+  [ ("petstore_auth", Inline (SecurityScheme
       { _securitySchemeType = SecuritySchemeOAuth2 (mempty & implicit ?~ OAuth2Flow
             { _oAuth2Params = OAuth2ImplicitFlow "http://swagger.io/api/oauth/dialog"
             , _oAath2RefreshUrl = Nothing
             , _oAuth2Scopes = []
             } )
-      , _securitySchemeDescription = Nothing })
+      , _securitySchemeDescription = Nothing }))
   ]
 
 oAuth2SecurityDefinitionsExample :: SecurityDefinitions
@@ -1001,5 +1006,27 @@ compositionSchemaExampleJSON = [aesonQQ|
         }
       }
   ]
+}
+|]
+
+refSchemaExampleJSON :: Value
+refSchemaExampleJSON = [aesonQQ|
+{
+  "openapi": "3.0.3",
+  "info": {
+    "version": "1.0.0",
+    "title": "Example using references"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "Foo": {
+        "type": "string"
+      },
+      "Bar": {
+        "$ref": "#/components/schemas/Foo"
+      }
+    }
+  }
 }
 |]


### PR DESCRIPTION
From how I understand the OpenAPI 3.0 spec, the following should be allowed and work as expected:

```yaml
components:
  schemas:
    Foo:
      type: string
    Bar:
      $ref: '#/components/schemas/Foo'
```
but since `type Definitions = InsOrdHashMap Text`, which is in turn used in `Components` (*without* `Referenced`), this doesn't parse correctly. This PR changes `Definitions` so that a `Referenced` is added in between, and updates other code to deal with the new possibility of a `Ref`. This is of course a breaking change.

(One use case for writing specs like this is in Haskell code generation: in Chordify's internal tool, a schema that's just a ref to another schema is turned into a newtype of that schema.)