### PR TITLE
Bound bumps

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -88,7 +88,7 @@ library
     , hashable                  >=1.2.7.0  && <1.5
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
-    , lens                      >=4.16.1   && <5.3
+    , lens                      >=4.16.1   && <5.4
     , optics-core               >=0.2      && <0.5
     , optics-th                 >=0.2      && <0.5
     , scientific                >=0.3.6.2  && <0.4

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -95,7 +95,7 @@ library
     , unordered-containers      >=0.2.9.0  && <0.3
     , uuid-types                >=1.0.3    && <1.1
     , vector                    >=0.12.0.1 && <0.14
-    , QuickCheck                >=2.10.1   && <2.15
+    , QuickCheck                >=2.10.1   && <2.16
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
`allow-newer: openapi3:lens` and `allow-newer: openapi3:QuickCheck` works for us on an internal project, provided that dependent packages are similarly relaxed. This PR passes `cabal test --constraint 'lens ^>=5.3' --constraint 'QuickCheck ^>=2.15' --allow-newer=insert-ordered-containers:lens --allow-newer=aeson:QuickCheck --allow-newer=quickcheck-instances:QuickCheck`, but you may want to hold off until the `allow-newer`s are not required.

When this does go through, can you please also make a Hackage metadata revision?

See also:

* https://github.com/phadej/insert-ordered-containers/pull/58
* https://github.com/haskell/aeson/issues/1096
* https://github.com/haskellari/qc-instances/issues/92