### PR TITLE
Bump dependencies for GHC 9.10

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -85,7 +85,7 @@ library
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.6
     , generics-sop              >=0.5.1.0  && <0.6
-    , hashable                  >=1.2.7.0  && <1.5
+    , hashable                  >=1.2.7.0  && <1.6
     , http-media                >=0.8.0.0  && <0.9
     , insert-ordered-containers >=0.2.3    && <0.3
     , lens                      >=4.16.1   && <5.4

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -66,10 +66,10 @@ library
 
   -- GHC boot libraries
   build-depends:
-      base             >=4.11.1.0  && <4.20
+      base             >=4.11.1.0  && <4.21
     , bytestring       >=0.10.8.2  && <0.13
     , containers       >=0.5.11.0  && <0.8
-    , template-haskell >=2.13.0.0  && <2.22
+    , template-haskell >=2.13.0.0  && <2.23
     , time             >=1.8.0.2   && <1.14
     , transformers     >=0.5.5.0   && <0.7
 
@@ -79,7 +79,7 @@ library
 
   -- other dependencies
   build-depends:
-      base-compat-batteries     >=0.11.1   && <0.14
+      base-compat-batteries     >=0.11.1   && <0.15
     , aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && < 2.3
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint


### PR DESCRIPTION
Tested using

    cabal build -w ghc-9.10.1 -c 'base-compat-batteries>=0.14' -c 'hashable >= 1.5' --allow-newer=insert-ordered-containers:hashable

See

* https://github.com/commercialhaskell/stackage/issues/7403