### PR TITLE
set an example value of zero for standard numeric values

### DIFF
--- a/src/Data/OpenApi/Internal/ParamSchema.hs
+++ b/src/Data/OpenApi/Internal/ParamSchema.hs
@@ -18,7 +18,7 @@
 module Data.OpenApi.Internal.ParamSchema where
 
 import Control.Lens
-import Data.Aeson (ToJSON (..))
+import Data.Aeson (ToJSON (..), Value(Number))
 import Data.Proxy
 import GHC.Generics
 
@@ -168,6 +168,7 @@ toParamSchemaBoundedIntegral _ = mempty
   & type_ ?~ OpenApiInteger
   & minimum_ ?~ fromInteger (toInteger (minBound :: a))
   & maximum_ ?~ fromInteger (toInteger (maxBound :: a))
+  & example ?~ Number 0
 
 instance ToParamSchema Char where
   toParamSchema _ = mempty


### PR DESCRIPTION
I find it quite noisy to always get the `maxBound` value of `Int` values as examples in my openapi spec. Sometimes it is even technically wrong because the bound is not inclusive and the example input is not accepted. By using a sensible default of `0`, both these issues are mitigated.