### PR TITLE
specify 'uuid' as format for UUID

### DIFF
--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -636,6 +636,7 @@ instance ToSchema () where
 instance ToSchema UUID.UUID where
   declareNamedSchema p = pure $ named "UUID" $ paramSchemaToSchema p
     & example ?~ toJSON (UUID.toText UUID.nil)
+    & format ?~ "uuid"
 
 instance (ToSchema a, ToSchema b) => ToSchema (a, b) where
   declareNamedSchema = fmap unname . genericDeclareNamedSchema defaultSchemaOptions


### PR DESCRIPTION
It's available in the registry: https://spec.openapis.org/registry/format/uuid

which apparently doesn't mandate tools to support it but even then, if they dont recognize the format, they must fallback on the type so this change should be a plus with no negative effects.