### PR TITLE
Use `nullable` for `Maybe` schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 ----------
 
+- (breaking) Use `nullable` for `Maybe` schemas [#113](https://github.com/biocad/openapi3/pull/113)
+
 3.2.4
 -----
 - Give `title` to sub schemas of sum types [#88](https://github.com/biocad/openapi3/pull/88).

--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -1,6 +1,6 @@
 cabal-version:       >=1.10
 name:                openapi3
-version:             3.2.4
+version:             3.3.0
 
 synopsis:            OpenAPI 3.0 data model
 category:            Web, Swagger, OpenApi

--- a/test/Data/OpenApi/SchemaSpec.hs
+++ b/test/Data/OpenApi/SchemaSpec.hs
@@ -102,7 +102,7 @@ spec = do
     context "Character" $ checkDefs (Proxy :: Proxy Character) ["Player", "Point"]
     context "MyRoseTree" $ checkDefs (Proxy :: Proxy MyRoseTree) ["RoseTree"]
     context "MyRoseTree'" $ checkDefs (Proxy :: Proxy MyRoseTree') ["myrosetree'"]
-    context "[Set (Unit, Maybe Color)]" $ checkDefs (Proxy :: Proxy [Set (Unit, Maybe Color)]) ["Unit", "Color"]
+    context "[Set (Unit, Maybe Color)]" $ checkDefs (Proxy :: Proxy [Set (Unit, Maybe Color)]) ["Unit", "Maybe_Color"]
     context "ResourceId" $ checkDefs (Proxy :: Proxy ResourceId) []
   describe "Inlining Schemas" $ do
     context "Paint" $ checkInlinedSchema (Proxy :: Proxy Paint) paintInlinedSchemaJSON

--- a/test/Data/OpenApiSpec.hs
+++ b/test/Data/OpenApiSpec.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE DeriveGeneric #-}
 module Data.OpenApiSpec where
 
 import Prelude ()
@@ -13,11 +14,13 @@ import Data.Aeson
 import Data.Aeson.QQ.Simple
 import Data.HashMap.Strict (HashMap)
 import qualified Data.HashSet.InsOrd as InsOrdHS
+import Data.Proxy (Proxy(..))
 import Data.Text (Text)
 
 import Data.OpenApi
 import SpecCommon
 import Test.Hspec hiding (example)
+import GHC.Generics (Generic)
 
 spec :: Spec
 spec = do
@@ -53,6 +56,8 @@ spec = do
       it "merged correctly" $ do
         let merged = oAuth2SecurityDefinitionsReadOpenApi <> oAuth2SecurityDefinitionsWriteOpenApi <> oAuth2SecurityDefinitionsEmptyOpenApi
         merged `shouldBe` oAuth2SecurityDefinitionsOpenApi
+  it "Type Parameters Example" $ do
+    toJSON typeParametersExample `shouldBe` typeParametersExampleJSON
 
 main :: IO ()
 main = hspec spec
@@ -1001,5 +1006,35 @@ compositionSchemaExampleJSON = [aesonQQ|
         }
       }
   ]
+}
+|]
+
+data TypeParameters a
+  = TypeParameters
+  { typeParametersField1 :: Maybe Double
+  , typeParametersField2 :: a
+  } deriving (Generic)
+
+instance ToSchema a => ToSchema (TypeParameters a)
+
+typeParametersExample :: Schema
+typeParametersExample = toSchema (Proxy :: Proxy (TypeParameters (Maybe Double)))
+
+typeParametersExampleJSON :: Value
+typeParametersExampleJSON = [aesonQQ|
+{
+  "properties": {
+    "typeParametersField1": {
+      "format": "double",
+      "type": "number"
+    },
+    "typeParametersField2": {
+      "format": "double",
+      "type": "number",
+      "nullable": true
+    }
+  },
+  "required": ["typeParametersField2"],
+  "type": "object"
 }
 |]


### PR DESCRIPTION
The `Generic`-derived schema for polymorphic datatypes is incorrect. The schema for a datatype like`data X a = X{ field :: a }` has `field` as a required property. This means that the schema for `X (Maybe something)` also has `field` marked as a required field. The optionality of the `Maybe` is forgotten. A service relying on the erroneous schema would expect a non-nullable value, but a service sending `X (Maybe something)` values can send `null` in the `field` propety, but a service relying on the erroneous schema will expect no `null` in `field`, leading to a runtime error.

Given `data X a = X{ field :: a }`, the `Generic`-derived schema *must* mark `field` as required, because it needs to work for all `a`. Therefore, `instance ToSchema a => ToSchema (Maybe a)` has to generate a `nullable` schema to be correct. Then the schema for `X (Maybe something)` will have required property `field` with a `nullable` schema for `something`.

This change changes the `ToSchema` instance for `Maybe a`. The schema for `Maybe a` is prefixed with `Maybe_` to distinguish it from the schema for `a`. Without this, `declareSchemaRef` will generate the same reference for an `a` or a `Maybe a`. When an API uses an `a` and a `Maybe a`, only one of the two schemas will make it into the `components.schemas` section (because of the name conflict). This can lead to a schema that says it produces non-nullable values, but may actually produce nulls.

This problem could also be solved by changing `declareSchemaRef` to strip the `nullable` property from the declared schema and return the nullability value alongside the `Referenced Schema`. This would increase sharing (you wouldn't have near duplicate schemas `X` and `Maybe_X`), and I think it would be cleaner, but at the cost of forcing downstream libraries (such as `servant-openapi3`) to explicitly handle that nullability information. I chose the solution that's compatible with current downstream code.

I *think* this supercedes the previous attempts at fixing `Maybe`:

* https://github.com/biocad/openapi3/pull/91
* https://github.com/biocad/openapi3/pull/103
