### PR TITLE
Raise bound: QuickCheck

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -97,7 +97,7 @@ library
     , unordered-containers      >=0.2.9.0  && <0.3
     , uuid-types                >=1.0.3    && <1.1
     , vector                    >=0.12.0.1 && <0.14
-    , QuickCheck                >=2.10.1   && <2.16
+    , QuickCheck                >=2.10.1   && <2.18
 
   default-language:    Haskell2010
 


### PR DESCRIPTION
Tested with:
* `cabal test --constraint 'QuickCheck ^>=2.16'`. 
* `cabal test --constraint 'QuickCheck ^>=2.17' --allow-newer=aeson:QuickCheck `

Could we please have a metadata revision also?

Fixes #112 