### PR TITLE
Update GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -181,7 +181,7 @@ jobs:
           chmod a+x $HOME/.cabal/bin/cabal-plan
           cabal-plan --version
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           path: source
       - name: initial cabal.project for sdist


### PR DESCRIPTION
Bump GitHub Actions to Node.js 24 compatible versions. Node.js 20 is deprecated June 2026.