### PR TITLE
Allow aeson 2.3

### DIFF
--- a/openapi3.cabal
+++ b/openapi3.cabal
@@ -83,7 +83,7 @@ library
   -- other dependencies
   build-depends:
       base-compat-batteries     >=0.11.1   && <0.16
-    , aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && < 2.3
+    , aeson                     >=1.4.2.0  && <1.6 || >=2.0.1.0 && < 2.4
     , aeson-pretty              >=0.8.7    && <0.9
     -- cookie 0.4.3 is needed by GHC 7.8 due to time>=1.4 constraint
     , cookie                    >=0.4.3    && <0.6


### PR DESCRIPTION
https://hackage.haskell.org/package/aeson-2.3.0.0/changelog
https://haskell.github.io/security-advisories/advisory/HSEC-2026-0007.html

Tested with

    cabal test --constraint=aeson==2.3.0.0 --allow-newer=insert-ordered-containers:aeson --allow-newer=aeson-pretty:aeson

PRs/issues on dependencies:

* https://github.com/informatikr/aeson-pretty/pull/49
* https://github.com/erikd/insert-ordered-containers/issues/10