### PR TITLE
Toschema seq instance

### DIFF
--- a/src/Data/OpenApi/Internal/Schema.hs
+++ b/src/Data/OpenApi/Internal/Schema.hs
@@ -37,6 +37,7 @@ import Data.Proxy
 import Data.Scientific (Scientific)
 import Data.Fixed (Fixed, HasResolution, Pico)
 import Data.Set (Set)
+import Data.Sequence (Seq)
 import Data.Semigroup
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
@@ -720,6 +721,8 @@ instance ToSchema a => ToSchema (Set a) where
       & uniqueItems ?~ True
 
 instance ToSchema a => ToSchema (HashSet a) where declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy (Set a))
+
+instance ToSchema a => ToSchema (Seq a) where declareNamedSchema _ = declareNamedSchema (Proxy :: Proxy [a])
 
 -- | @since 2.2.1
 instance ToSchema a => ToSchema (NonEmpty a) where

--- a/test/Data/OpenApi/Schema/GeneratorSpec.hs
+++ b/test/Data/OpenApi/Schema/GeneratorSpec.hs
@@ -23,6 +23,7 @@ import           Data.Map                            (Map, fromList)
 import           Data.Monoid                         (mempty)
 import           Data.Proxy
 import           Data.Proxy
+import           Data.Sequence                       (Seq)
 import           Data.Set                            (Set)
 import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
@@ -68,6 +69,7 @@ spec = do
     prop "T.Text" $ shouldValidate (Proxy :: Proxy T.Text)
     prop "TL.Text" $ shouldValidate (Proxy :: Proxy TL.Text)
     prop "[String]" $ shouldValidate (Proxy :: Proxy [String])
+    prop "Seq String" $ shouldValidate (Proxy :: Proxy (Seq String))
     -- prop "(Maybe [Int])" $ shouldValidate (Proxy :: Proxy (Maybe [Int]))
     prop "(IntMap String)" $ shouldValidate (Proxy :: Proxy (IntMap String))
     prop "(Set Bool)" $ shouldValidate (Proxy :: Proxy (Set Bool))

--- a/test/Data/OpenApi/Schema/ValidationSpec.hs
+++ b/test/Data/OpenApi/Schema/ValidationSpec.hs
@@ -25,6 +25,7 @@ import           Data.List.NonEmpty.Compat           (NonEmpty (..), nonEmpty)
 import           Data.Map                            (Map, fromList)
 import           Data.Monoid                         (mempty)
 import           Data.Proxy
+import           Data.Sequence                       (Seq)
 import           Data.Set                            (Set)
 import qualified Data.Text                           as T
 import qualified Data.Text.Lazy                      as TL
@@ -75,6 +76,7 @@ spec = do
     prop "T.Text" $ shouldValidate (Proxy :: Proxy T.Text)
     prop "TL.Text" $ shouldValidate (Proxy :: Proxy TL.Text)
     prop "[String]" $ shouldValidate (Proxy :: Proxy [String])
+    prop "Seq String" $ shouldValidate (Proxy :: Proxy (Seq String))
     -- prop "(Maybe [Int])" $ shouldValidate (Proxy :: Proxy (Maybe [Int]))
     prop "(IntMap String)" $ shouldValidate (Proxy :: Proxy (IntMap String))
     prop "(Set Bool)" $ shouldValidate (Proxy :: Proxy (Set Bool))


### PR DESCRIPTION
I noticed there's no `ToSchema` instance for [Seq](https://hackage.haskell.org/package/containers/docs/Data-Sequence.html#t:Seq), so I added one!